### PR TITLE
Fixes for MacOs Compatibility

### DIFF
--- a/src/cd++/evt/event.h
+++ b/src/cd++/evt/event.h
@@ -34,7 +34,7 @@ struct Event
 
 	Event( const VTime = VTime::Zero, const Port * = NULL, const AbstractValue & = Real(0) );
 
-	bool operator < ( const Event &ev )
+	bool operator < ( const Event &ev ) const
 		{return time < ev.time;}
 		
 	Event &operator =( const Event &ev ) ;

--- a/src/cd++/model/pmodeladm.h
+++ b/src/cd++/model/pmodeladm.h
@@ -17,7 +17,14 @@
 /** include files **/
 #include <vector>
 #include <map>
-#include <hash_map>		//Template hash_map
+
+// If OS is Apple based, hashmap is defined differently
+#if defined __GNUC__ || defined __APPLE__
+       #include <ext/hash_map>
+#else
+       #include <hash_map>
+#endif
+
 #include <string>           // Template std::string
 #include "strutil.h"		// hash<std::string>
 #include "modelid.h"

--- a/src/cd++/parser/tokit.h
+++ b/src/cd++/parser/tokit.h
@@ -15,6 +15,9 @@
 
 #include <string>
 #include <iterator>
+#if defined __GNUC__ || defined __APPLE__
+    #include <iostream>
+#endif
 
 class TokenIterator
 {

--- a/src/cd++/utils/prnutil.h
+++ b/src/cd++/utils/prnutil.h
@@ -22,19 +22,6 @@
 #include <iterator>
 
 /** inline **/
-
-template< class T1, class T2 >          
-inline
-std::ostream &operator<<( std::ostream &out,  const std::map< T1, T2, std::less< T1 > > &c )
-{
-	typename std::map< T1, T2, std::less< T1 > >::const_iterator cursor( c.begin() ) ;
-
-	for( ; cursor != c.end() ; cursor ++ )
-		out << cursor->first << " = " << cursor->second << std::endl ;
-
-	return out;
-}
-
 template< class T >
 inline
 std::ostream &operator<<( std::ostream &out, const std::list< T > &l )
@@ -54,5 +41,18 @@ std::ostream &operator <<( std::ostream &out, const std::pair<T1, T2> &p )
 	out << "First: " << p.first << std::endl << "Second: " << p.second << std::endl ;  
 	return out ;
 }
+
+template< class T1, class T2 >          
+inline
+std::ostream &operator<<( std::ostream &out,  const std::map< T1, T2, std::less< T1 > > &c )
+{
+	typename std::map< T1, T2, std::less< T1 > >::const_iterator cursor( c.begin() ) ;
+
+	for( ; cursor != c.end() ; cursor ++ )
+		out << cursor->first << " = " << cursor->second << std::endl ;
+
+	return out;
+}
+
 
 #endif   //__PRNUTIL_H 

--- a/src/cd++/utils/strutil.h
+++ b/src/cd++/utils/strutil.h
@@ -19,7 +19,12 @@
 
 #include <ctype.h>   // tolower 
 #include <cstdio>
-#include <hash_map>
+// If OS is Apple based, hashmap is defined differently
+#if defined __GNUC__ || defined __APPLE__
+       #include <ext/hash_map>
+#else
+       #include <hash_map>
+#endif
 #include "real.h"
 
 std::string lowerCase( const std::string &str );


### PR DESCRIPTION
Some imports are placed differently inside MacOS C standard library, like **hashmap**. 
Also, since the default C++ compiles is Clang, some warning are raised as errors. A fix is provided for them.