### PR TITLE
Files created in make added to gitignore

### DIFF
--- a/src/cd++/parser/cdlang/.gitignore
+++ b/src/cd++/parser/cdlang/.gitignore
@@ -1,0 +1,2 @@
+gram.h
+gram.output


### PR DESCRIPTION
The files
- src/cd++/parser/cdlang/gram.h
- src/cd++/parser/cdlang/gram.output
are created when `make` is executed and they appear as untracked files.